### PR TITLE
Disable HARDWRAPS markdown extension

### DIFF
--- a/src/main/java/com/gitblit/utils/MarkdownUtils.java
+++ b/src/main/java/com/gitblit/utils/MarkdownUtils.java
@@ -17,6 +17,7 @@ package com.gitblit.utils;
 
 import static org.pegdown.Extensions.ALL;
 import static org.pegdown.Extensions.ANCHORLINKS;
+import static org.pegdown.Extensions.HARDWRAPS;
 import static org.pegdown.Extensions.SMARTYPANTS;
 
 import java.io.IOException;
@@ -77,7 +78,7 @@ public class MarkdownUtils {
 	 */
 	public static String transformMarkdown(String markdown, LinkRenderer linkRenderer) {
 		try {
-			PegDownProcessor pd = new PegDownProcessor(ALL & ~SMARTYPANTS & ~ANCHORLINKS);
+			PegDownProcessor pd = new PegDownProcessor(ALL & ~SMARTYPANTS & ~ANCHORLINKS & ~HARDWRAPS);
 			RootNode astRoot = pd.parseMarkdown(markdown.toCharArray());
 			return new WorkaroundHtmlSerializer(linkRenderer == null ? new LinkRenderer() : linkRenderer).toHtml(astRoot);
 		} catch (ParsingTimeoutException e) {

--- a/src/test/java/com/gitblit/tests/MarkdownUtilsTest.java
+++ b/src/test/java/com/gitblit/tests/MarkdownUtilsTest.java
@@ -33,6 +33,8 @@ public class MarkdownUtilsTest extends GitblitUnitTest {
 				MarkdownUtils.transformMarkdown("**THIS ** is a test"));
 		assertEquals("<p>** THIS** is a test</p>",
 				MarkdownUtils.transformMarkdown("** THIS** is a test"));
+		assertEquals("<p>This is also a test</p>",
+				MarkdownUtils.transformMarkdown("This is also\na test"));
 
 		assertEquals("<table><tr><td>test</td></tr></table>",
 				MarkdownUtils.transformMarkdown("<table><tr><td>test</td></tr></table>"));


### PR DESCRIPTION
The HARDWRAPS extension is intended to be used like GitHub Flavored Markdown (GFM). GFM only uses hard wraps in comments, whereas the markdown rendered by GitBlit is generally documents not comments.
