### PR TITLE
Fixes #1079: user+domain submitted in different formats resolves to different user accounts when Windows authentication is used.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -48,7 +48,7 @@
 	<classpathentry kind="lib" path="ext/httpcore-4.3.3.jar" sourcepath="ext/src/httpcore-4.3.3.jar" />
 	<classpathentry kind="lib" path="ext/commons-logging-1.1.3.jar" sourcepath="ext/src/commons-logging-1.1.3.jar" />
 	<classpathentry kind="lib" path="ext/commons-codec-1.7.jar" sourcepath="ext/src/commons-codec-1.7.jar" />
-	<classpathentry kind="lib" path="ext/org.eclipse.jdt.annotation-1.1.0.jar" />
+	<classpathentry kind="lib" path="ext/org.eclipse.jdt.annotation-1.1.0.jar" sourcepath="ext/src/org.eclipse.jdt.annotation-1.1.0.jar" />
 	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.1.1.201511131810-r.jar" />
 	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.52.jar" sourcepath="ext/src/bcprov-jdk15on-1.52.jar" />
 	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.52.jar" sourcepath="ext/src/bcmail-jdk15on-1.52.jar" />
@@ -93,10 +93,5 @@
 	<classpathentry kind="lib" path="ext/mockito-core-1.10.19.jar" sourcepath="ext/src/mockito-core-1.10.19.jar" />
 	<classpathentry kind="lib" path="ext/objenesis-2.1.jar" sourcepath="ext/src/objenesis-2.1.jar" />
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
-	<classpathentry kind="src" path="src/main/dagger">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin/classes" />
 </classpath>

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -490,7 +490,9 @@
           <root url="jar://$MODULE_DIR$/ext/org.eclipse.jdt.annotation-1.1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES />
+        <SOURCES>
+          <root url="jar://$MODULE_DIR$/ext/src/org.eclipse.jdt.annotation-1.1.0.jar!/" />
+        </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">

--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1692,9 +1692,9 @@ realm.container.autoCreateAccounts = false
 # the webapp container used can fill the session with user informations
 #
 # SINCE 1.7.0
-realm.container.autoAccounts.displayName = 
-realm.container.autoAccounts.emailAddress = 
-realm.container.autoAccounts.locale = 
+realm.container.autoAccounts.displayName =
+realm.container.autoAccounts.emailAddress =
+realm.container.autoAccounts.locale =
 
 # If the user's created by the webapp container is given this role,
 # the user created will be a admin user.
@@ -1724,7 +1724,14 @@ realm.windows.permitBuiltInAdministrators = true
 # if "." (dot) is specified, ONLY the local account database will be used.
 #
 # SINCE 1.3.0
-realm.windows.defaultDomain =
+realm.windows.defaultDomain = ""
+
+# Allow or prohibit login with a user from a different domain than the specified defaultDomain
+#
+# if this is set to true then realm.windows.defaultDomain must be populated.
+#
+# SINCE 1.7.2
+realm.windows.allowMultipleDomainAuthentication = false
 
 # The PAM service name for authentication.
 # default: system-auth

--- a/src/main/java/com/gitblit/utils/WindowsLogonInfo.java
+++ b/src/main/java/com/gitblit/utils/WindowsLogonInfo.java
@@ -1,0 +1,177 @@
+package com.gitblit.utils;
+
+/**
+ * A utility class that parses raw user provided logon as a string into a structured set of Windows logon info.
+ * <p>Supported input formats are:</p>
+ * <ul>
+ * <li>Lowest-Level Logon name: domain\\user</li>
+ * <li>User Principal Name: user@domain.example.com</li>
+ * <li>Username only (provided a default domain name is specified): user</li>
+ * </ul>
+ * <p>If a domain name cannot be extracted from the raw input, an optionally provided default domain name is used instead.
+ *
+ * @author Frederic Thevenet
+ */
+public class WindowsLogonInfo {
+    private String user;
+    private String domain;
+    private String netBIOSDomain;
+    private boolean valid;
+
+    /**
+     * Gets the parsed user name.
+     *
+     * @return the parsed user name
+     */
+    public String getUser() {
+        return user;
+    }
+
+    /**
+     * Gets the parsed domain name
+     * <p>The NetBIOS domain name is the legacy format that is trimmed from a DNS suffix.</p>
+     *
+     * @return the parsed domain name, in lower case.
+     */
+    public String getNetBIOSDomain() {
+        return this.netBIOSDomain;
+    }
+
+    /**
+     * Gets the parsed domain name as a UPN suffix
+     * <p>The User Principal Name suffix is the made out of the domain name plus the DNS suffix (i.e. domain.example.com)/ </p>
+     *
+     * @return
+     */
+    public String getUPNSuffix() {
+        return this.domain;
+    }
+
+    /**
+     * Returns true if the input string was successfully parsed into a valid set of login info, false otherwise.
+     *
+     * @return true if the input string was successfully parsed into a valid set of login info, false otherwise.
+     */
+    public boolean isValid() {
+        return this.valid;
+    }
+
+    /**
+     * Returns the parsed user logon info in the Down-Level Logon Name format.
+     * <p>The down-level logon name format is used to specify a domain and a user account in that domain, for example, DOMAIN\\user.</p>
+     *
+     * @return the parsed user logon info in the Down-Level Logon Name format.
+     */
+    public String getDownLevelLogonName() {
+        if (!isValid()) {
+            return null;
+        }
+        return getNetBIOSDomain() + "\\" + getUser();
+    }
+
+    /**
+     * Returns the parsed user logon info in the User Principal Name format.
+     * <p>User principal name (UPN) format is used to specify an Internet-style name, such as user@domain.example.com.</p>
+     *
+     * @return the parsed user logon info in the User Principal Name format.
+     */
+    public String getUserPrincipalName() {
+        if (!isValid()) {
+            return null;
+        }
+        return getUser() + "@" + getUPNSuffix();
+    }
+
+    /**
+     * Parses an input string into a set of Windows login info.
+     * <p>A domain name must be present in rawLoginString</p>
+     *
+     * @param rawLoginString the input string to parse
+     * @return a set of Windows login info.
+     */
+    public static WindowsLogonInfo Parse(String rawLoginString) {
+        return new WindowsLogonInfo(rawLoginString, null);
+    }
+
+    /**
+     * Parses an input string into a set of Windows login info.
+     * <p>If a domain isn't provided in the input, the provided default domain is used.</p>
+     *
+     * @param rawLoginString the input string to parse
+     * @param defaultDomain  the domain name to use if one cannot be extracted from the provide input.
+     * @return a set of Windows login info.
+     */
+    public static WindowsLogonInfo Parse(String rawLoginString, String defaultDomain) {
+        return new WindowsLogonInfo(rawLoginString, defaultDomain);
+    }
+
+    @Override
+    public String toString() {
+        if (!this.isValid()) {
+            return "invalid";
+        }
+        return getDownLevelLogonName();
+    }
+
+    private WindowsLogonInfo(String rawLoginString, String defaultDomain) {
+        this.valid = tryParseLoginString(rawLoginString, defaultDomain);
+    }
+
+    private boolean tryParseLoginString(String rawUsername, String defaultDomain) {
+        if (rawUsername == null || rawUsername.trim().length() == 0) {
+            // Illegal Argument provided: input is null or blank
+            return false;
+        }
+        // Parse raw string for domain and user name
+        int slashIdx = rawUsername.indexOf('\\');
+        int atIdx = rawUsername.indexOf('@');
+        if (slashIdx != -1 && atIdx != -1) {
+            // Failed to parse input: both separators found
+            return false;
+        }
+        if (slashIdx != -1) {
+            this.domain = rawUsername.substring(0, slashIdx);
+            this.user = rawUsername.substring(slashIdx + 1, rawUsername.length());
+        }
+        else if (atIdx != -1) {
+            this.domain = rawUsername.substring(atIdx + 1, rawUsername.length());
+            this.user = rawUsername.substring(0, atIdx);
+        }
+        else {
+            this.user = rawUsername;
+        }
+        if (this.user.trim().length() == 0) {
+            // Failed to identify a valid user name.
+            return false;
+        }
+        //Substitute default domain if a valid could not be extracted from raw string
+        if (this.domain == null || this.domain.trim().length() == 0) {
+            if (defaultDomain == null) {
+                // Failed to identify a valid domain name.
+                return false;
+            }
+            this.domain = defaultDomain;
+        }
+        // Extract legacy NetBIOS domain name.
+        this.netBIOSDomain = trimDNSsuffixFromDomainName(domain).toUpperCase();
+        // Success
+        return true;
+    }
+
+    /**
+     * Remove the DNS suffix from the provided domain name, if present.
+     *
+     * @param domainName
+     * @return domain name with the DNS suffix removed.
+     * <p>If "." (dot) is provided, it is return untouched.<br>
+     * If null is provided, the method returns null.</p>
+     */
+    public static String trimDNSsuffixFromDomainName(String domainName) {
+        if (domainName != null) {
+            int idx = domainName.indexOf('.');
+            idx = (idx < 1) ? domainName.length() : idx;
+            domainName = domainName.substring(0, idx);
+        }
+        return domainName;
+    }
+}

--- a/src/test/config/test-users.conf
+++ b/src/test/config/test-users.conf
@@ -5,6 +5,11 @@
 	emailMeOnMyTicketChanges = true
 	role = "#admin"
 	role = "#notfederated"
+[user "sampleuser"]
+	password = sampleuser
+	accountType = LOCAL
+	emailMeOnMyTicketChanges = true
+	role = "#none"
 [team "admins"]
 	role = "#none"
 	accountType = LOCAL

--- a/src/test/java/com/gitblit/tests/WindowsLogonInfoParsingTest.java
+++ b/src/test/java/com/gitblit/tests/WindowsLogonInfoParsingTest.java
@@ -1,0 +1,90 @@
+package com.gitblit.tests;
+
+import com.gitblit.utils.WindowsLogonInfo;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * WindowsLogonInfo tests
+ *
+ * @author Frederic Thevenet
+ */
+public class WindowsLogonInfoParsingTest {
+    @Test
+    public void testLoginInfoParsing() {
+        Map<String, Boolean> testCases = new HashMap<>();
+        testCases.put("bob@corp", true);
+        testCases.put("corp\\bob", true);
+        testCases.put("bob", true);
+        testCases.put("corp\\", false);
+        testCases.put("\\bob", true);
+        testCases.put("@corp", false);
+        testCases.put("bob@", true);
+        testCases.put(null, false);
+        testCases.put("bob@corp\\bob", false);
+        testCases.put(".\\bob", true);
+        testCases.put("bob@corp.company.com", true);
+        testCases.put("corp.company.com\\bob", true);
+        runTest(testCases, "default");
+    }
+
+    @Test
+    public void testLoginInfoParsingWithDefaultFqdn() {
+        Map<String, Boolean> testCases = new HashMap<>();
+        testCases.put("bob@corp", true);
+        testCases.put("corp\\bob", true);
+        testCases.put("bob", true);
+        testCases.put("corp\\", false);
+        testCases.put("\\bob", true);
+        testCases.put("@corp", false);
+        testCases.put("bob@", true);
+        testCases.put(null, false);
+        testCases.put("bob@corp\\bob", false);
+        testCases.put(".\\bob", true);
+        testCases.put("bob@corp.company.com", true);
+        testCases.put("corp.company.com\\bob", true);
+        runTest(testCases, "default.company.com");
+    }
+
+    @Test
+    public void testLoginInfoParsingWithoutDefaultDomain() {
+        Map<String, Boolean> testCases = new HashMap<>();
+        testCases.put("bob@corp", true);
+        testCases.put("corp\\bob", true);
+        testCases.put("bob", false);
+        testCases.put("corp\\", false);
+        testCases.put("\\bob", false);
+        testCases.put("@corp", false);
+        testCases.put("bob@", false);
+        testCases.put(null, false);
+        testCases.put("bob@corp\\bob", false);
+        testCases.put(".\\bob", true);
+        testCases.put("bob@corp.company.com", true);
+        testCases.put("corp.company.com\\bob", true);
+        runTest(testCases, null);
+    }
+
+    private void runTest(Map<String, Boolean> testCases, String defaultDomain) {
+        for (Map.Entry<String, Boolean> test : testCases.entrySet()) {
+            WindowsLogonInfo loginInfo = defaultDomain != null ?
+                    WindowsLogonInfo.Parse(test.getKey(), defaultDomain) : WindowsLogonInfo.Parse(test.getKey());
+
+            assertTrue("Test case " + test.toString() + ": does not match the predicted result", loginInfo.isValid() == test.getValue());
+            if (loginInfo.isValid()) {
+                assertNotNull("Test case " + test.toString() + ": domain shouldn't be null", loginInfo.getNetBIOSDomain());
+                assertNotNull("Test case " + test.toString() + ": user shouldn't be null", loginInfo.getUser());
+                assertTrue("Test case " + test.toString() + ": Unexpected user name: " + loginInfo.getUser(),
+                        "bob".equalsIgnoreCase(loginInfo.getUser()));
+                assertTrue("Test case " + test.toString() + ": Unexpected domain name: "+ loginInfo.getNetBIOSDomain(),
+                        loginInfo.getNetBIOSDomain().equals("CORP") ||
+                                loginInfo.getNetBIOSDomain().equals(".") ||
+                                loginInfo.getNetBIOSDomain().equals("DEFAULT"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
**\- Fixes #1079: user+domain submitted in different formats resolves to different user accounts when Windows authentication is used.**
As explain in referenced issue.

**\- Added a utility class that helps build and represent a valid set of Windows logon info.**
Used to help parse and validate user provided credentials in whatever supported format and resolve to the same identity.
Tests for this class are provided.

**\- New property "realm.windows.allowMultipleDomainAuthentication": Allow or prohibit login with a user from a different domain than the specified defaultDomain.**
While addressing the simple parsing issue mentioned above, it appeared to me that the user model is not rich enough to properly support the notion of multiple domains.
That means that if one wants to be able to distinguish two users with the same handle but registered in two different domains (and I think that one might ;-) ), it is necessary to craft a gitblit user account name that contains the domain in order to lift any ambiguity.
The fact that that piece of data is used as a key in the internal user db (user.conf), also as the root for private repos (with the ~ prefix) which ultimately must be resolved as a file system path, and that it can be part of a git url, seriously limits the choices of characters that can be used as a separator in between the domain and the user name.
Both conventional formats, _domain\user_ and _user@domain_ are out, as they either cause invalid FS path or urls, so I opted for domain_user.
But recognizing that this looks kind of awkward and that for most multiple domain support might not be a requirement (also it could break existing scripts that explicitly populate users.conf), I opted to make that behavior optional: 
- With "realm.windows.allowMultipleDomainAuthentication" set to false, then a default domain name must be provided, and only users from that domain will be able to login. Disambiguation is therefore useless, so the bare username is used as a key in users.conf, and everything looks nice. (default behavior)
- if "realm.windows.allowMultipleDomainAuthentication" is set to true, then user accounts are identified as "domain_user".

With all that said, I think that this is only a stop gap solution and that what's really needed is  an evolution of the usermodel as well as a refactoring of how root folder for private repos are handled.
I'd argue that this is especially needed as the issues here are most likely to appear also when using LDAP authentication or any auth scheme that support a similar notion to domains.
