### PR TITLE
Add support for Jenkins access token fixes #1423

### DIFF
--- a/src/main/distrib/data/groovy/jenkins.groovy
+++ b/src/main/distrib/data/groovy/jenkins.groovy
@@ -69,11 +69,15 @@ logger.info("jenkins hook triggered by ${user.username} for ${repository.name}")
 // gitblit.properties or web.xml
 def jenkinsUrl = gitblit.getString('groovy.jenkinsServer', 'http://yourserver/jenkins')
 
+// define your jenkins access token here or set groovy.jenkinsToken in 
+// gitblit.properties or web.xml (https://github.com/jenkinsci/git-plugin/#push-notification-from-repository)
+def jenkinsToken = gitblit.getString('groovy.jenkinsToken', 'yourtoken')
+
 // define the repository base url
 def jenkinsGitbaseurl = gitblit.getString('groovy.jenkinsGitbaseurl', "${url}/r")
 
 // define the trigger url
-def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=" + jenkinsGitbaseurl + "/${repository.name}"
+def triggerUrl = jenkinsUrl + "/git/notifyCommit?url=" + jenkinsGitbaseurl + "/${repository.name}" + "&token=" + jenkinsToken
 
 // trigger the build
 new URL(triggerUrl).getContent()


### PR DESCRIPTION
This pullrequest extends the Jenkins post receive hook with the possibility to configure an access token. This token is needed since Git Plugin 4.11.4 (see https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-284)