### PR TITLE
Fix Moxie URL in build.xml (#1441)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup Moxie
         run: |
-          wget http://gitblit.github.io/moxie/maven/com/gitblit/moxie/moxie+ant/0.9.4/moxie+ant-0.9.4.tar.gz
+          wget http://gitblit-org.github.io/moxie/maven/com/gitblit/moxie/moxie+ant/0.9.4/moxie+ant-0.9.4.tar.gz
           tar -xzf moxie+ant-0.9.4.tar.gz
           moxie-0.9.4/bin/moxie -version
 

--- a/README.markdown
+++ b/README.markdown
@@ -57,5 +57,5 @@ Make sure to clone using `--recursive` OR to execute `git submodule update --ini
 Building Tips & Tricks
 ----------------------
 1. If you are running Ant from an ANSI-capable console, consider setting the `MX_COLOR` environment variable before executing Ant.<pre>set MX_COLOR=true</pre>
-2. The build script will honor your Maven proxy settings.  If you need to fine-tune this, please review the [settings.moxie](http://gitblit.github.io/moxie/settings.html) documentation.
+2. The build script will honor your Maven proxy settings.  If you need to fine-tune this, please review the [settings.moxie](http://gitblit-org.github.io/moxie/settings.html) documentation.
 

--- a/build.xml
+++ b/build.xml
@@ -5,11 +5,11 @@
 		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		Retrieve Moxie Toolkit
 		
-		documentation @ http://gitblit.github.io/moxie
+		documentation @ http://gitblit-org.github.io/moxie
 		~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	-->
 	<property name="moxie.version" value="0.9.4" />
-	<property name="moxie.url" value="http://gitblit.github.io/moxie/maven" />
+	<property name="moxie.url" value="http://gitblit-org.github.io/moxie/maven" />
 	<property name="moxie.jar" value="moxie-toolkit-${moxie.version}.jar" />
 	<property name="moxie.dir" value="${user.home}/.moxie" />
 

--- a/src/main/java/com/gitblit/manager/PluginManager.java
+++ b/src/main/java/com/gitblit/manager/PluginManager.java
@@ -315,7 +315,7 @@ public class PluginManager implements IPluginManager, PluginStateListener {
 
 	@Override
 	public synchronized boolean refreshRegistry(boolean verifyChecksum) {
-		String dr = "http://gitblit.github.io/gitblit-registry/plugins.json";
+		String dr = "http://gitblit-org.github.io/gitblit-registry/plugins.json";
 		String url = runtimeManager.getSettings().getString(Keys.plugins.registry, dr);
 		try {
 			File file = download(url, verifyChecksum);


### PR DESCRIPTION
Looks like the GitHub org name changed at some point, and the Moxie URL in `build.xml` needs to be updated.

#1441 