### PR TITLE
Update Git clients list on empty repository page

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>the official, command-line Git</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Windows file explorer integration (requires official, command-line Git)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git for the Eclipse IDE (based on JGit, like Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>C# frontend for Git that features Windows Explorer and Visual Studio integration</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>a Mac OS X Git client</td></tr>
@@ -46,7 +45,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>A Java Git and Mercurial client for Windows, Mac, and Linux</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>A free Git and Mercurial client for Windows & Mac</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>A free Git client for Windows &amp; Mac</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>A free Git and Mercurial client for Windows &amp; Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>a Mac OS X Git client</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_cs.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_cs.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>oficiální, z příkazové řádky</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Integrace do Průzkumníka Windows (vyžaduje oficiální řádkový Git)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git pro Eclipse IDE (založený na JGit, jako Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>C# frontend pro Git, který obsahuje integraci do Průzkumníka Windows a do Visual Studia</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>Mac OS X Git klient</td></tr>
@@ -46,6 +45,7 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Na Javě založený klient pro Git and Mercurial pro Windows, Mac a Linux</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Volný Git klient pro Windows a Mac</td></tr>
 			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Volný Git a Mercurial klient pro Windows a Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Mac OS X Git klient</td></tr>
 		</tbody>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_de.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_de.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>der offizielle Kommandozeilen-Git-Client</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Windows Datei Explorer Integration (erfordert den offiziellen Kommandozeilen-Client)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git für die Eclipse IDE (basiert auf JGit, ebenso wie Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>C# Frontend für Git mit Windows Explorer und Visual Studio Integration</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>ein Mac OS X Git Client</td></tr>
@@ -46,6 +45,7 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Ein Java Git und Mercurial Client für Windows, Mac und Linux</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Ein freier Git Client für Windows und Mac</td></tr>
 			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Ein freier Git und Mercurial Client für Windows und Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Ein Mac OS X Git Client</td></tr>
 		</tbody>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_es.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_es.html
@@ -37,7 +37,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>El Git oficial en l&iacute;nea de comandos</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Explorador de archivos integrado en Windows (necesita Git oficial en l&iacute;nea de comandos)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git para el IDE de Eclipse (basado en JGit, como Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>Interfaz de usuario gr&aacute;fico Git en C# con integraci&oacute;n en IE y en Visual Studio</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>Cliente Git para Mac OS X</td></tr>
@@ -48,7 +47,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>aplicaci&oacute;n Java (necesita Git oficial en l&iacute;nea de comandos)</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Un cliente Git gratuito para Mac, Mercurial, y SVN</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Un cliente Git gratuito para Mac y Windows</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Un cliente Git y Mercurial gratuito para Mac y Windows</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Cliente Git para Mac OS X</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_fr.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_fr.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>Version officielle de Git, en ligne de commande</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Int&eacute;gration de Git dans l'explorateur de fichiers Windows (n&eacute;cessite l'application officielle Git, en ligne de commande)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Module Git pour l'IDE Eclipse (bas&eacute; sur JGit, comme Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>Client pour Git &eacute;crit en C#, int&eacute;gr&eacute; &agrave; l'Explorateur de fichier de Windows et &agrave; Visual Studio</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>Client Git pour Mac OS X</td></tr>
@@ -46,6 +45,7 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Un client Git et Mercurial &eacute;crit Java pour Windows, Mac, et Linux</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Un client Git gratuit pour Windows et Mac</td></tr>
 			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Un client Git et Mercurial gratuit pour Windows et Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Client Git pour Mac OS</td></tr>
 		</tbody>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_it.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_it.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>la versione ufficiale di Git, da riga di comando</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Integrazione per Windows Explorer (richiede la versione ufficiale di Git da riga di comando)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git per ambienti di sviluppo basati su Eclipse (basato su JGit, come Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>applicazione C# che integra Git in Windows Explorer e Visual Studio</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>un client Git per Mac OS X</td></tr>
@@ -46,7 +45,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Un client Git e Mercurial scritto in Java per Windows, Mac, and Linux</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Un client Git e Mercurial gratuito per Windows & Mac</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Un client Git gratuito per Windows &amp; Mac</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Un client Git e Mercurial gratuito per Windows &amp; Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Un client Git per Mac OS X</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ja.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ja.html
@@ -35,7 +35,6 @@
     <table>
     <tbody>
       <tr><td><a href="http://git-scm.com">Git</a></td><td>本家コマンドライン版 Git</td></tr>
-      <tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Windows エクスプローラ統合型 GUI (要 本家コマンドライン版 Git)</td></tr>
       <tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>エクリプス IDE 向け Git (Gitblit に似た JGit 使用 )</td></tr>
       <tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>Windows エクスプローラとVisual Studio に統合された、Git の C# 製 UI</td></tr>
       <tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>Mac OS X 向け Git クライアント</td></tr>
@@ -46,6 +45,7 @@
     <table>
     <tbody>
       <tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Windows, Mac, Linux 向け、Java製 Git &amp; Mercurial クライアント</td></tr>
+      <tr><td><a href="https://git-fork.com/">Fork</a></td><td>フリーの Windows, Mac 向け Git クライアント</td></tr>
       <tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>フリーの Windows, Mac 向け Git &amp; Mercurial クライアント</td></tr>
       <tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Mac OS X 向け Git クライアント</td></tr>
     </tbody>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ko.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ko.html
@@ -36,7 +36,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>명령어 기반 공식 Git</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>윈도의 파일 탐색기에 통합된 UI 클라이언트 (명령어 기반 공식 Git 필요)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>이클립스 IDE 플러그인 (Gitblit 과 같은 JGit 기반)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>윈도 탐색기와 비주얼스튜디어를 위한 C#으로 개발된 기능</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>맥 OS X 용 Git 클라이언트</td></tr>
@@ -47,6 +46,7 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>자바 어플리케이션 (명령어 기반 공식 Git 필요)</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>윈도와 맥에서 사용 가능한 Git 용 무료 클라이언트</td></tr>
 			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>윈도와 맥에서 사용 가능한 Git 과 Mercurial용 무료 클라이언트</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>맥 OS X 용 Git 클라이언트</td></tr>
 		</tbody>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_nl.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_nl.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>de officiele, command-line Git</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Windows bestandsverkenner integratie (officiele command-line Git is wel nodig)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git voor de Eclipse IDE (gebaseerd op JGit, zoals Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>C# frontend voor Git met Windows Explorer en Visual Studio integratie</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>een Mac OS X Git client</td></tr>
@@ -46,7 +45,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Een Java Git, Mercurial, en SVN client applicatie (officiele command-line Git is wel nodig)</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Een gratis Mac Client voor Git en Mercurial</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Een gratis Mac en Windows Client voor Git</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Een gratis Mac en Windows Client voor Git en Mercurial</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>een Mac OS X Git client</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_no.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_no.html
@@ -34,8 +34,7 @@
 		<h4>Open Source Git Clients</h4>
 		<table>
 		<tbody>
-			<tr><td>a href="http://git-scm.com">Git</a> - den offisielle, kommando-linje git</td></tr>
-			<tr><td>a href="http://tortoisegit.googlecode.com">TortoiseGit</a> - Windows filutforsker integrasjon (krever den offisielle kommando-linje git versjonen installert</td></tr>
+			<tr><td><a href="http://git-scm.com">Git</a> - den offisielle, kommando-linje git</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a> - Git for Eclipse IDE (basert p\u00e5 JGit, akkurat som Gitblit er)</tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a> - En C# frontend for Git som integrerer med filutforskeren og Visual Studio.</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a> - En  git klient for OS X</td></tr>
@@ -46,8 +45,9 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a> - En Git og Mercurial klient for Windows, Mac, og Linux</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a> - En gratis Git klient for Windows og Mac</td></tr>
 			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a> - En gratis Git og Mercurial klient for Windows og Mac</td></tr>
-			<tr><td>a href="http://www.git-tower.com/">Tower</a> - En git klient for Mac OS X </td></tr>
+			<tr><td><a href="http://www.git-tower.com/">Tower</a> - En git klient for Mac OS X </td></tr>
 		</tbody>
 		</table>
 	</div>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_pl.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_pl.html
@@ -37,7 +37,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>Oficjalny klient, dost&#281;pny przez lini&#281; polece&#324;</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Rozszerzenie eksploratora Windows (wymaga oficjalnego, dost&#281;pnego przez lini&#281; polece&#324; klienta)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>GIT dla edytora Eclipse (oparty o JGit, podobnie jak Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>napisana w C# fasada na GIT, udost&#281;pniaj&#261;ca integracj&#281; dla Windows Explorer oraz Visual Studio</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>klient GIT na Mac OS X</td></tr>
@@ -48,7 +47,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>aplikacja napisana w Javie (wymaga oficjalnego, dost&#281;pnego przez lini&#281; polece&#324; klienta)</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>darmowy klient GIT, Mercurial i SVN na Mac OS X</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>darmowy klient GIT na Mac OS X i Windows</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>darmowy klient GIT i Mercurial na Mac OS X i Windows</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>klient GIT na Mac OS X</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_pt_BR.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_pt_BR.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>o Git oficial através de linhas de comando</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Faz integração do Explorer do Windows com o Git (por isso requer o Git Oficial)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git para a IDE Eclipse (baseada no JGit, como o Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>Interface (em C#) para o Git cuja a característica é a integração com o Windows Explorer e o Visual Studio</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>um Cliente do Git para Mac OS X</td></tr>
@@ -46,7 +45,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Aplicação Client (em Java) para Git e Mercurial (por isso requer o Git Oficial)</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Client gratuito para o Mac que suporta Git e Mercurial</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>Client gratuito para o Mac e Windows que suporta Git</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>Client gratuito para o Mac e Windows que suporta Git e Mercurial</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>um Cliente do Git para Mac OS X</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ru.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_ru.html
@@ -35,7 +35,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>the official, command-line Git</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>Windows file explorer integration (requires official, command-line Git)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git for the Eclipse IDE (based on JGit, like Gitblit)</td></tr>
 			<tr><td><a href="hhttp://gitextensions.github.io">Git Extensions</a></td><td>C# frontend for Git that features Windows Explorer and Visual Studio integration</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>a Mac OS X Git client</td></tr>
@@ -46,7 +45,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>A Java Git and Mercurial client for Windows, Mac, and Linux</td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>A free Git and Mercurial client for Windows & Mac</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>A free Git client for Windows &amp; Mac</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>A free Git and Mercurial client for Windows &amp; Mac</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>a Mac OS X Git client</td></tr>
 		</tbody>
 		</table>

--- a/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_zh_CN.html
+++ b/src/main/java/com/gitblit/wicket/pages/EmptyRepositoryPage_zh_CN.html
@@ -36,7 +36,6 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://git-scm.com">Git</a></td><td>官方, 命令行版本 Git</td></tr>
-			<tr><td><a href="http://tortoisegit.googlecode.com">TortoiseGit</a></td><td>与 Windows 资源管理器集成 (需要官方, 命令行 Git 的支持)</td></tr>
 			<tr><td><a href="http://eclipse.org/egit">Eclipse/EGit</a></td><td>Git for the Eclipse IDE (基于 JGit, 类似 Gitblit)</td></tr>
 			<tr><td><a href="http://gitextensions.github.io">Git Extensions</a></td><td>C# 版本的 Git 前端，与 Windows 资源管理器和 Visual Studio 集成</td></tr>
 			<tr><td><a href="http://rowanj.github.io/gitx/">GitX-dev</a></td><td>Mac OS X Git 客户端</td></tr>
@@ -47,7 +46,8 @@
 		<table>
 		<tbody>
 			<tr><td><a href="http://www.syntevo.com/smartgithg">SmartGit/Hg</a></td><td>Java 版本的支持 Git, Mercurial 和 SVN 客户端应用 </td></tr>
-			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>免费的 Mac Git Mercurial 以及 SVN 客户端 and Mercurial</td></tr>
+			<tr><td><a href="https://git-fork.com/">Fork</a></td><td>免费的 Mac 以及 Windows Git 客户端</td></tr>
+			<tr><td><a href="http://www.sourcetreeapp.com/">SourceTree</a></td><td>免费的 Mac 以及 Windows Git 以及 Mercurial 客户端</td></tr>
 			<tr><td><a href="http://www.git-tower.com/">Tower</a></td><td>Mac OS X Git 客户端</td></tr>
 		</tbody>
 		</table>


### PR DESCRIPTION
The page shown for an empty repository lists suggestions for Git clients, mostly GUI ones, and links to their web pages.

The TortoiseGit client entry is removed since the URL is no longer valid. The excellent client Fork is added to the closed source clients section.

This commit also cleans up some other entries, fixing broken tags, escaping ampersands and removing outdated or wrong information.