### PR TITLE
Fix single quotes in MessageFormat patterns.

### DIFF
--- a/src/main/java/com/gitblit/authority/GitblitAuthority.java
+++ b/src/main/java/com/gitblit/authority/GitblitAuthority.java
@@ -281,7 +281,7 @@ public class GitblitAuthority extends JFrame implements X509Log {
 		this.userService = loadUsers(folder);
 		System.out.println(Constants.baseFolder$ + " set to " + folder);
 		if (userService == null) {
-			JOptionPane.showMessageDialog(this, MessageFormat.format("Sorry, {0} doesn't look like a Gitblit GO installation.", folder));
+			JOptionPane.showMessageDialog(this, MessageFormat.format("Sorry, {0} doesn''t look like a Gitblit GO installation.", folder));
 		} else {
 			// build empty certificate model for all users
 			Map<String, UserCertificateModel> map = new HashMap<String, UserCertificateModel>();

--- a/src/main/java/com/gitblit/servlet/GitFilter.java
+++ b/src/main/java/com/gitblit/servlet/GitFilter.java
@@ -294,7 +294,7 @@ public class GitFilter extends AccessRestrictionFilter {
 				// confirm valid characters in repository name
 				Character c = StringUtils.findInvalidCharacter(repository);
 				if (c != null) {
-					logger.error(MessageFormat.format("Invalid character '{0}' in repository name {1}!", c, repository));
+					logger.error(MessageFormat.format("Invalid character ''{0}'' in repository name {1}!", c, repository));
 					return null;
 				}
 

--- a/src/main/java/com/gitblit/utils/JGitUtils.java
+++ b/src/main/java/com/gitblit/utils/JGitUtils.java
@@ -795,7 +795,7 @@ public class JGitUtils {
 			}
 		} catch (Throwable t) {
 			if (throwError) {
-				error(t, repository, "{0} can't find {1} in tree {2}", path, tree.name());
+				error(t, repository, "{0} can''t find {1} in tree {2}", path, tree.name());
 			}
 		} finally {
 			rw.dispose();
@@ -837,7 +837,7 @@ public class JGitUtils {
 			ObjectLoader ldr = repository.open(blob.getId(), Constants.OBJ_BLOB);
 			content = ldr.getCachedBytes();
 		} catch (Throwable t) {
-			error(t, repository, "{0} can't find blob {1}", objectId);
+			error(t, repository, "{0} can''t find blob {1}", objectId);
 		} finally {
 			rw.dispose();
 		}
@@ -2117,7 +2117,7 @@ public class JGitUtils {
 				}
 			}
 		} catch (Throwable t) {
-			error(t, repository, "{0} can't find {1} in commit {2}", path, commit.name());
+			error(t, repository, "{0} can''t find {1} in commit {2}", path, commit.name());
 		} finally {
 			rw.dispose();
 			tw.close();


### PR DESCRIPTION
Within a String, a pair of single quotes can be used to quote any arbitrary characters except single quotes. For example, pattern string "'{0}'" represents string "{0}", not a FormatElement. A single quote itself must be represented by doubled single quotes '' throughout a String.