### PR TITLE
Update some outdated, and sometimes wrong, logger format strings

### DIFF
--- a/src/main/java/com/gitblit/service/GarbageCollectorService.java
+++ b/src/main/java/com/gitblit/service/GarbageCollectorService.java
@@ -15,7 +15,6 @@
  */
 package com.gitblit.service;
 
-import java.text.MessageFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -143,7 +142,7 @@ public class GarbageCollectorService implements Runnable {
 				break;
 			}
 			if (isCollectingGarbage(repositoryName)) {
-				logger.warn(MessageFormat.format("Already collecting garbage from {0}?!?", repositoryName));
+				logger.warn("Already collecting garbage from {}?!?", repositoryName);
 				continue;
 			}
 			boolean garbageCollected = false;
@@ -153,12 +152,12 @@ public class GarbageCollectorService implements Runnable {
 				model = repositoryManager.getRepositoryModel(repositoryName);
 				repository = repositoryManager.getRepository(repositoryName);
 				if (repository == null) {
-					logger.warn(MessageFormat.format("GCExecutor is missing repository {0}?!?", repositoryName));
+					logger.warn("GCExecutor is missing repository {}?!?", repositoryName);
 					continue;
 				}
 
 				if (!repositoryManager.isIdle(repository)) {
-					logger.debug(MessageFormat.format("GCExecutor is skipping {0} because it is not idle", repositoryName));
+					logger.debug("GCExecutor is skipping {} because it is not idle", repositoryName);
 					continue;
 				}
 
@@ -166,11 +165,11 @@ public class GarbageCollectorService implements Runnable {
 				// disabling *all* access to this repository from Gitblit.
 				// Think of this as a clutch in a manual transmission vehicle.
 				if (!setGCStatus(repositoryName, GCStatus.COLLECTING)) {
-					logger.warn(MessageFormat.format("Can not acquire GC lock for {0}, skipping", repositoryName));
+					logger.warn("Can not acquire GC lock for {}, skipping", repositoryName);
 					continue;
 				}
 
-				logger.debug(MessageFormat.format("GCExecutor locked idle repository {0}", repositoryName));
+				logger.debug("GCExecutor locked idle repository {}", repositoryName);
 
 				Git git = new Git(repository);
 				GarbageCollectCommand gc = git.gc();
@@ -196,7 +195,7 @@ public class GarbageCollectorService implements Runnable {
 				boolean hasGarbage = sizeOfLooseObjects > 0;
 				if (hasGarbage && (hasEnoughGarbage || shouldCollectGarbage)) {
 					long looseKB = sizeOfLooseObjects/1024L;
-					logger.info(MessageFormat.format("Collecting {1} KB of loose objects from {0}", repositoryName, looseKB));
+					logger.info("Collecting {} KB of loose objects from {}", looseKB, repositoryName );
 
 					// do the deed
 					gc.call();
@@ -204,7 +203,7 @@ public class GarbageCollectorService implements Runnable {
 					garbageCollected = true;
 				}
 			} catch (Exception e) {
-				logger.error("Error collecting garbage in " + repositoryName, e);
+				logger.error("Error collecting garbage in {}", repositoryName, e);
 			} finally {
 				// cleanup
 				if (repository != null) {
@@ -219,7 +218,7 @@ public class GarbageCollectorService implements Runnable {
 
 				// reset the GC lock
 				releaseLock(repositoryName);
-				logger.debug(MessageFormat.format("GCExecutor released GC lock for {0}", repositoryName));
+				logger.debug("GCExecutor released GC lock for {}", repositoryName);
 			}
 		}
 

--- a/src/main/java/com/gitblit/service/LuceneService.java
+++ b/src/main/java/com/gitblit/service/LuceneService.java
@@ -172,7 +172,7 @@ public class LuceneService implements Runnable {
 				Repository repository = repositoryManager.getRepository(model.name);
 				if (repository == null) {
 					if (repositoryManager.isCollectingGarbage(model.name)) {
-						logger.info(MessageFormat.format("Skipping Lucene index of {0}, busy garbage collecting", repositoryName));
+						logger.info("Skipping Lucene index of {}, busy garbage collecting", repositoryName);
 					}
 					continue;
 				}
@@ -200,9 +200,8 @@ public class LuceneService implements Runnable {
 
 				if (result.success) {
 					if (result.commitCount > 0) {
-						String msg = "Built {0} Lucene index from {1} commits and {2} files across {3} branches in {4} secs";
-						logger.info(MessageFormat.format(msg, model.name, result.commitCount,
-								result.blobCount, result.branchCount, result.duration()));
+						logger.info("Built {} Lucene index from {} commits and {} files across {} branches in {} secs",
+									model.name, result.commitCount,	result.blobCount, result.branchCount, result.duration());
 					}
 				} else {
 					String msg = "Could not build {0} Lucene index!";
@@ -213,17 +212,15 @@ public class LuceneService implements Runnable {
 				IndexResult result = updateIndex(model, repository);
 				if (result.success) {
 					if (result.commitCount > 0) {
-						String msg = "Updated {0} Lucene index with {1} commits and {2} files across {3} branches in {4} secs";
-						logger.info(MessageFormat.format(msg, model.name, result.commitCount,
-								result.blobCount, result.branchCount, result.duration()));
+						logger.info("Updated {} Lucene index with {} commits and {} files across {} branches in {} secs",
+									model.name, result.commitCount, result.blobCount, result.branchCount, result.duration());
 					}
 				} else {
-					String msg = "Could not update {0} Lucene index!";
-					logger.error(MessageFormat.format(msg, model.name));
+					logger.error("Could not update {} Lucene index!", model.name);
 				}
 			}
 		} catch (Throwable t) {
-			logger.error(MessageFormat.format("Lucene indexing failure for {0}", model.name), t);
+			logger.error("Lucene indexing failure for {}", model.name, t);
 		}
 	}
 
@@ -239,7 +236,7 @@ public class LuceneService implements Runnable {
 				searcher.getIndexReader().close();
 			}
 		} catch (Exception e) {
-			logger.error("Failed to close index searcher for " + repositoryName, e);
+			logger.error("Failed to close index searcher for {}", repositoryName, e);
 		}
 
 		try {
@@ -248,7 +245,7 @@ public class LuceneService implements Runnable {
 				writer.close();
 			}
 		} catch (Exception e) {
-			logger.error("Failed to close index writer for " + repositoryName, e);
+			logger.error("Failed to close index writer for {}", repositoryName, e);
 		}
 	}
 
@@ -262,7 +259,7 @@ public class LuceneService implements Runnable {
 			try {
 				writers.get(writer).close();
 			} catch (Throwable t) {
-				logger.error("Failed to close Lucene writer for " + writer, t);
+				logger.error("Failed to close Lucene writer for {}", writer, t);
 			}
 		}
 		writers.clear();
@@ -272,7 +269,7 @@ public class LuceneService implements Runnable {
 			try {
 				searchers.get(searcher).getIndexReader().close();
 			} catch (Throwable t) {
-				logger.error("Failed to close Lucene searcher for " + searcher, t);
+				logger.error("Failed to close Lucene searcher for {}", searcher, t);
 			}
 		}
 		searchers.clear();
@@ -594,7 +591,7 @@ public class LuceneService implements Runnable {
 			resetIndexSearcher(model.name);
 			result.success();
 		} catch (Exception e) {
-			logger.error("Exception while reindexing " + model.name, e);
+			logger.error("Exception while reindexing {}", model.name, e);
 		}
 		return result;
 	}
@@ -673,7 +670,7 @@ public class LuceneService implements Runnable {
 			result.commitCount++;
 			result.success = index(repositoryName, doc);
 		} catch (Exception e) {
-			logger.error(MessageFormat.format("Exception while indexing commit {0} in {1}", commit.getId().getName(), repositoryName), e);
+			logger.error("Exception while indexing commit {} in {}", commit.getId().getName(), repositoryName, e);
 		}
 		return result;
 	}
@@ -701,10 +698,10 @@ public class LuceneService implements Runnable {
 		writer.commit();
 		int numDocsAfter = writer.numDocs();
 		if (numDocsBefore == numDocsAfter) {
-			logger.debug(MessageFormat.format("no records found to delete {0}", query.toString()));
+			logger.debug("no records found to delete {}", query.toString());
 			return false;
 		} else {
-			logger.debug(MessageFormat.format("deleted {0} records with {1}", numDocsBefore - numDocsAfter, query.toString()));
+			logger.debug("deleted {} records with {}", numDocsBefore - numDocsAfter, query.toString());
 			return true;
 		}
 	}
@@ -833,7 +830,7 @@ public class LuceneService implements Runnable {
 			}
 			result.success = true;
 		} catch (Throwable t) {
-			logger.error(MessageFormat.format("Exception while updating {0} Lucene index", model.name), t);
+			logger.error("Exception while updating {} Lucene index", model.name, t);
 		}
 		return result;
 	}
@@ -876,7 +873,7 @@ public class LuceneService implements Runnable {
 			resetIndexSearcher(repositoryName);
 			return true;
 		} catch (Exception e) {
-			logger.error(MessageFormat.format("Exception while incrementally updating {0} Lucene index", repositoryName), e);
+			logger.error("Exception while incrementally updating {} Lucene index", repositoryName, e);
 		}
 		return false;
 	}
@@ -1049,7 +1046,7 @@ public class LuceneService implements Runnable {
 				results.add(result);
 			}
 		} catch (Exception e) {
-			logger.error(MessageFormat.format("Exception while searching for {0}", text), e);
+			logger.error("Exception while searching for {}", text, e);
 		}
 		return new ArrayList<SearchResult>(results);
 	}

--- a/src/main/java/com/gitblit/service/MirrorService.java
+++ b/src/main/java/com/gitblit/service/MirrorService.java
@@ -119,7 +119,7 @@ public class MirrorService implements Runnable {
 
 				repository = repositoryManager.getRepository(repositoryName);
 				if (repository == null) {
-					logger.warn(MessageFormat.format("MirrorExecutor is missing repository {0}?!?", repositoryName));
+					logger.warn("MirrorExecutor is missing repository {}?!?", repositoryName);
 					continue;
 				}
 
@@ -204,7 +204,7 @@ public class MirrorService implements Runnable {
 					}
 				}
 			} catch (Exception e) {
-				logger.error("Error updating mirror " + repositoryName, e);
+				logger.error("Error updating mirror {}", repositoryName, e);
 			} finally {
 				// cleanup
 				if (repository != null) {

--- a/src/main/java/com/gitblit/tickets/BranchTicketService.java
+++ b/src/main/java/com/gitblit/tickets/BranchTicketService.java
@@ -16,7 +16,6 @@
 package com.gitblit.tickets;
 
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -169,20 +168,19 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 						if (!ids.contains(ticketId)) {
 							ids.add(ticketId);
 							TicketModel ticket = getTicket(repository, ticketId);
-							log.info(MessageFormat.format("indexing ticket #{0,number,0}: {1}",
-									ticketId, ticket.title));
+							log.info("indexing ticket #{}: {}",	ticketId, ticket.title);
 							indexer.index(ticket);
 						}
 					}
 					long end = System.nanoTime();
-					log.info("incremental indexing of {0} ticket(s) completed in {1} msecs",
+					log.info("incremental indexing of {} ticket(s) completed in {} msecs",
 							ids.size(), TimeUnit.NANOSECONDS.toMillis(end - start));
 				} finally {
 					db.close();
 				}
 				break;
 			default:
-				log.warn("Unexpected receive type {} in BranchTicketService.onRefsChanged" + cmd.getType());
+				log.warn("Unexpected receive type {} in BranchTicketService.onRefsChanged", cmd.getType());
 				break;
 			}
 		} catch (Exception e) {
@@ -216,10 +214,10 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 				Result res = cmd.rename();
 				switch (res) {
 				case RENAMED:
-					log.info(db.getDirectory() + " " + cmd.getRefLogMessage());
+					log.info("{} {}", db.getDirectory(), cmd.getRefLogMessage());
 					return getTicketsBranch(db);
 				default:
-					log.error("failed to rename " + oldRef.getName() + " => " + BRANCH + " (" + res.name() + ")");
+					log.error("failed to rename {} => {} ({})", oldRef.getName(), BRANCH, res.name());
 				}
 			} catch (IOException e) {
 				log.error("failed to rename tickets branch", e);
@@ -288,7 +286,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 				return JGitUtils.getStringContent(db, tree, file, Constants.ENCODING);
 			}
 		} catch (IOException e) {
-			log.error("failed to read " + file, e);
+			log.error("failed to read {}", file, e);
 		} finally {
 			if (rw != null) {
 				rw.close();
@@ -506,8 +504,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 						}
 					}
 				} catch (Exception e) {
-					log.error("failed to deserialize {}/{}\n{}",
-							new Object [] { repository, path.path, e.getMessage()});
+					log.error("failed to deserialize {}/{}\n{}", repository, path.path, e.getMessage());
 					log.error(null, e);
 				}
 			}
@@ -701,8 +698,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 				success = commitIndex(db, index, deletedBy, "- " + ticket.number);
 
 			} catch (Throwable t) {
-				log.error(MessageFormat.format("Failed to delete ticket {0,number,0} from {1}",
-						ticket.number, db.getDirectory()), t);
+				log.error("Failed to delete ticket {} from {}",	ticket.number, db.getDirectory(), t);
 			} finally {
 				// release the treewalk
 				if (treeWalk != null) {
@@ -733,8 +729,7 @@ public class BranchTicketService extends ITicketService implements RefsChangedLi
 			success = commitIndex(db, index, change.author, "#" + ticketId);
 
 		} catch (Throwable t) {
-			log.error(MessageFormat.format("Failed to commit ticket {0,number,0} to {1}",
-					ticketId, db.getDirectory()), t);
+			log.error("Failed to commit ticket {} to {}", ticketId, db.getDirectory(), t);
 		} finally {
 			db.close();
 		}

--- a/src/main/java/com/gitblit/tickets/FileTicketService.java
+++ b/src/main/java/com/gitblit/tickets/FileTicketService.java
@@ -17,7 +17,6 @@ package com.gitblit.tickets;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -274,8 +273,7 @@ public class FileTicketService extends ITicketService {
 						}
 					}
 				} catch (Exception e) {
-					log.error("failed to deserialize {}/{}\n{}",
-							new Object [] { repository, journal, e.getMessage()});
+					log.error("failed to deserialize {}/{}\n{}", repository, journal, e.getMessage());
 					log.error(null, e);
 				}
 			}
@@ -481,8 +479,7 @@ public class FileTicketService extends ITicketService {
 			FileUtils.writeContent(file, journal);
 			success = true;
 		} catch (Throwable t) {
-			log.error(MessageFormat.format("Failed to commit ticket {0,number,0} to {1}",
-					ticketId, db.getDirectory()), t);
+			log.error("Failed to commit ticket {} to {}", ticketId, db.getDirectory(), t);
 		} finally {
 			db.close();
 		}

--- a/src/main/java/com/gitblit/tickets/ITicketService.java
+++ b/src/main/java/com/gitblit/tickets/ITicketService.java
@@ -363,7 +363,7 @@ public abstract class ITicketService implements IManager {
 			}
 			labelsCache.put(key,  Collections.unmodifiableList(list));
 		} catch (Exception e) {
-			log.error("invalid tickets settings for " + repository, e);
+			log.error("invalid tickets settings for {}", repository, e);
 		} finally {
 			db.close();
 		}
@@ -408,7 +408,7 @@ public abstract class ITicketService implements IManager {
 			config.setString(LABEL, label, COLOR, lb.color);
 			config.save();
 		} catch (IOException e) {
-			log.error("failed to create label " + label + " in " + repository, e);
+			log.error("failed to create label {} in {}", label, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -436,7 +436,7 @@ public abstract class ITicketService implements IManager {
 
 			return true;
 		} catch (IOException e) {
-			log.error("failed to update label " + label + " in " + repository, e);
+			log.error("failed to update label {} in {}", label, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -477,7 +477,7 @@ public abstract class ITicketService implements IManager {
 
 			return true;
 		} catch (IOException e) {
-			log.error("failed to rename label " + oldName + " in " + repository, e);
+			log.error("failed to rename label {} in {}", oldName, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -508,7 +508,7 @@ public abstract class ITicketService implements IManager {
 
 			return true;
 		} catch (IOException e) {
-			log.error("failed to delete label " + label + " in " + repository, e);
+			log.error("failed to delete label {} in {}", label, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -543,15 +543,14 @@ public abstract class ITicketService implements IManager {
 					try {
 						milestone.due = new SimpleDateFormat(DUE_DATE_PATTERN).parse(due);
 					} catch (ParseException e) {
-						log.error("failed to parse {} milestone {} due date \"{}\"",
-								new Object [] { repository, name, due });
+						log.error("failed to parse {} milestone {} due date \"{}\"", repository, name, due, e);
 					}
 				}
 				list.add(milestone);
 			}
 			milestonesCache.put(key, Collections.unmodifiableList(list));
 		} catch (Exception e) {
-			log.error("invalid tickets settings for " + repository, e);
+			log.error("invalid tickets settings for {}", repository, e);
 		} finally {
 			db.close();
 		}
@@ -617,7 +616,7 @@ public abstract class ITicketService implements IManager {
 
 			milestonesCache.remove(repository.name);
 		} catch (IOException e) {
-			log.error("failed to create milestone " + milestone + " in " + repository, e);
+			log.error("failed to create milestone {} in {}", milestone, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -651,7 +650,7 @@ public abstract class ITicketService implements IManager {
 			milestonesCache.remove(repository.name);
 			return true;
 		} catch (IOException e) {
-			log.error("failed to update milestone " + milestone + " in " + repository, e);
+			log.error("failed to update milestone {} in {}", milestone, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -724,7 +723,7 @@ public abstract class ITicketService implements IManager {
 
 			return true;
 		} catch (IOException e) {
-			log.error("failed to rename milestone " + oldName + " in " + repository, e);
+			log.error("failed to rename milestone {} in {}", oldName, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -788,7 +787,7 @@ public abstract class ITicketService implements IManager {
 			}
 			return true;
 		} catch (IOException e) {
-			log.error("failed to delete milestone " + milestone + " in " + repository, e);
+			log.error("failed to delete milestone {} in {}", milestone, repository, e);
 		} finally {
 			if (db != null) {
 				db.close();
@@ -1219,8 +1218,7 @@ public abstract class ITicketService implements IManager {
 		TicketModel ticket = getTicket(repository, ticketId);
 		boolean success = deleteTicketImpl(repository, ticket, deletedBy);
 		if (success) {
-			log.info(MessageFormat.format("Deleted {0} ticket #{1,number,0}: {2}",
-					repository.name, ticketId, ticket.title));
+			log.info("Deleted {} ticket #{}: {}", repository.name, ticketId, ticket.title);
 			ticketsCache.invalidate(new TicketKey(repository, ticketId));
 			indexer.delete(ticket);
 			return true;

--- a/src/main/java/com/gitblit/tickets/RedisTicketService.java
+++ b/src/main/java/com/gitblit/tickets/RedisTicketService.java
@@ -181,7 +181,7 @@ public class RedisTicketService extends ITicketService {
 			Boolean exists = jedis.exists(key(repository, KeyType.journal, ticketId));
 			return exists != null && exists;
 		} catch (JedisException e) {
-			log.error("failed to check hasTicket from Redis @ " + getUrl(), e);
+			log.error("failed to check hasTicket from Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -205,7 +205,7 @@ public class RedisTicketService extends ITicketService {
 				ids.add(ticketId);
 			}
 		} catch (JedisException e) {
-			log.error("failed to assign new ticket id in Redis @ " + getUrl(), e);
+			log.error("failed to assign new ticket id in Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -241,7 +241,7 @@ public class RedisTicketService extends ITicketService {
 			long ticketNumber = jedis.incr(key);
 			return ticketNumber;
 		} catch (JedisException e) {
-			log.error("failed to assign new ticket id in Redis @ " + getUrl(), e);
+			log.error("failed to assign new ticket id in Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -300,7 +300,7 @@ public class RedisTicketService extends ITicketService {
 			// sort the tickets by creation
 			Collections.sort(list);
 		} catch (JedisException e) {
-			log.error("failed to retrieve tickets from Redis @ " + getUrl(), e);
+			log.error("failed to retrieve tickets from Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -338,7 +338,7 @@ public class RedisTicketService extends ITicketService {
 			log.debug("rebuilt ticket {} from Redis @ {}", ticketId, getUrl());
 			return ticket;
 		} catch (JedisException e) {
-			log.error("failed to retrieve ticket from Redis @ " + getUrl(), e);
+			log.error("failed to retrieve ticket from Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -371,7 +371,7 @@ public class RedisTicketService extends ITicketService {
 			}
 			return changes;
 		} catch (JedisException e) {
-			log.error("failed to retrieve journal from Redis @ " + getUrl(), e);
+			log.error("failed to retrieve journal from Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -454,9 +454,9 @@ public class RedisTicketService extends ITicketService {
 			t.exec();
 
 			success = true;
-			log.debug("deleted ticket {} from Redis @ {}", "" + ticket.number, getUrl());
+			log.debug("deleted ticket {} from Redis @ {}", ticket.number, getUrl());
 		} catch (JedisException e) {
-			log.error("failed to delete ticket from Redis @ " + getUrl(), e);
+			log.error("failed to delete ticket from Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -497,10 +497,10 @@ public class RedisTicketService extends ITicketService {
 			t.rpush(key(repository, KeyType.journal, ticketId), journal);
 			t.exec();
 
-			log.debug("updated ticket {} in Redis @ {}", "" + ticketId, getUrl());
+			log.debug("updated ticket {} in Redis @ {}", ticketId, getUrl());
 			return true;
 		} catch (JedisException e) {
-			log.error("failed to update ticket cache in Redis @ " + getUrl(), e);
+			log.error("failed to update ticket cache in Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -532,7 +532,7 @@ public class RedisTicketService extends ITicketService {
 			}
 			success = true;
 		} catch (JedisException e) {
-			log.error("failed to delete all tickets in Redis @ " + getUrl(), e);
+			log.error("failed to delete all tickets in Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {
@@ -561,7 +561,7 @@ public class RedisTicketService extends ITicketService {
 			t.exec();
 			success = true;
 		} catch (JedisException e) {
-			log.error("failed to rename tickets in Redis @ " + getUrl(), e);
+			log.error("failed to rename tickets in Redis @ {}", getUrl(), e);
 			pool.returnBrokenResource(jedis);
 			jedis = null;
 		} finally {

--- a/src/main/java/com/gitblit/tickets/TicketIndexer.java
+++ b/src/main/java/com/gitblit/tickets/TicketIndexer.java
@@ -17,7 +17,6 @@ package com.gitblit.tickets;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -214,10 +213,10 @@ public class TicketIndexer {
 			closeSearcher();
 			int numDocsAfter = writer.numDocs();
 			if (numDocsBefore == numDocsAfter) {
-				log.debug(MessageFormat.format("no records found to delete in {0}", repository));
+				log.debug("no records found to delete in {}", repository);
 				return false;
 			} else {
-				log.debug(MessageFormat.format("deleted {0} records in {1}", numDocsBefore - numDocsAfter, repository));
+				log.debug("deleted {} records in {}", numDocsBefore - numDocsAfter, repository);
 				return true;
 			}
 		} catch (Exception e) {
@@ -287,7 +286,7 @@ public class TicketIndexer {
 			IndexWriter writer = getWriter();
 			return delete(ticket.repository, ticket.number, writer);
 		} catch (Exception e) {
-			log.error("Failed to delete ticket " + ticket.number, e);
+			log.error("Failed to delete ticket {}", ticket.number, e);
 		}
 		return false;
 	}
@@ -311,10 +310,10 @@ public class TicketIndexer {
 		closeSearcher();
 		int numDocsAfter = writer.numDocs();
 		if (numDocsBefore == numDocsAfter) {
-			log.debug(MessageFormat.format("no records found to delete in {0}", repository));
+			log.debug("no records found to delete in {}", repository);
 			return false;
 		} else {
-			log.debug(MessageFormat.format("deleted {0} records in {1}", numDocsBefore - numDocsAfter, repository));
+			log.debug("deleted {} records in {}", numDocsBefore - numDocsAfter, repository);
 			return true;
 		}
 	}
@@ -383,7 +382,7 @@ public class TicketIndexer {
 				results.add(result);
 			}
 		} catch (Exception e) {
-			log.error(MessageFormat.format("Exception while searching for {0}", text), e);
+			log.error("Exception while searching for {}", text, e);
 		}
 		return new ArrayList<QueryResult>(results);
 	}
@@ -435,7 +434,7 @@ public class TicketIndexer {
 				results.add(result);
 			}
 		} catch (Exception e) {
-			log.error(MessageFormat.format("Exception while searching for {0}", queryText), e);
+			log.error("Exception while searching for {}", queryText, e);
 		}
 		return new ArrayList<QueryResult>(results);
 	}

--- a/src/main/java/com/gitblit/tickets/TicketNotifier.java
+++ b/src/main/java/com/gitblit/tickets/TicketNotifier.java
@@ -34,10 +34,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.gitblit.Constants;
@@ -96,6 +96,8 @@ public class TicketNotifier {
 	private final String addPattern = "<span style=\"color:darkgreen;\">+{0}</span>";
 	private final String delPattern = "<span style=\"color:darkred;\">-{0}</span>";
 
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
 	public TicketNotifier(
 			IRuntimeManager runtimeManager,
 			INotificationManager notificationManager,
@@ -152,7 +154,7 @@ public class TicketNotifier {
 
 			return mailing;
 		} catch (Exception e) {
-			Logger.getLogger(getClass()).error("failed to queue mailing for #" + ticket.number, e);
+			log.error("failed to queue mailing for #{}", ticket.number, e);
 		}
 		return null;
 	}
@@ -203,7 +205,7 @@ public class TicketNotifier {
 				diffstat = DiffUtils.getDiffStat(repo, base, patchset.tip);
 				commits = JGitUtils.getRevLog(repo, base, patchset.tip);
 			} catch (Exception e) {
-				Logger.getLogger(getClass()).error("failed to get changed paths", e);
+				log.error("failed to get changed paths", e);
 			} finally {
 				if (repo != null) {
 					repo.close();
@@ -552,9 +554,7 @@ public class TicketNotifier {
 					if (user.canView(repository)) {
 						toAddresses.add(user.emailAddress);
 					} else {
-						LoggerFactory.getLogger(getClass()).warn(
-								MessageFormat.format("ticket {0}-{1,number,0}: {2} can not receive notification",
-										repository.name, ticket.number, user.username));
+						log.warn("ticket {}-{}: {} can not receive notification", repository.name, ticket.number, user.username);
 					}
 				}
 			}
@@ -594,9 +594,7 @@ public class TicketNotifier {
 					if (user.canView(repository)) {
 						ccAddresses.add(user.emailAddress);
 					} else {
-						LoggerFactory.getLogger(getClass()).warn(
-								MessageFormat.format("ticket {0}-{1,number,0}: {2} can not receive notification",
-										repository.name, ticket.number, user.username));
+						log.warn("ticket {}-{}: {} can not receive notification", repository.name, ticket.number, user.username);
 					}
 				}
 			}


### PR DESCRIPTION
The code uses old, outdated forms of slf4j log message formatting.
This PR updates this for the `tickets` and `services` packages.