### PR TITLE
Updating some components to fixe identified vulnerable dependencies detected using grype.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,19 +9,19 @@
 	<classpathentry kind="lib" path="ext/guice-5.1.0.jar" sourcepath="ext/src/guice-5.1.0.jar" />
 	<classpathentry kind="lib" path="ext/javax.inject-1.jar" sourcepath="ext/src/javax.inject-1.jar" />
 	<classpathentry kind="lib" path="ext/aopalliance-1.0.jar" sourcepath="ext/src/aopalliance-1.0.jar" />
-	<classpathentry kind="lib" path="ext/guava-31.1-jre.jar" sourcepath="ext/src/guava-31.1-jre.jar" />
+	<classpathentry kind="lib" path="ext/guava-32.1.3-jre.jar" sourcepath="ext/src/guava-32.1.3-jre.jar" />
 	<classpathentry kind="lib" path="ext/failureaccess-1.0.1.jar" sourcepath="ext/src/failureaccess-1.0.1.jar" />
 	<classpathentry kind="lib" path="ext/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
 	<classpathentry kind="lib" path="ext/jsr305-3.0.2.jar" sourcepath="ext/src/jsr305-3.0.2.jar" />
-	<classpathentry kind="lib" path="ext/checker-qual-3.12.0.jar" sourcepath="ext/src/checker-qual-3.12.0.jar" />
-	<classpathentry kind="lib" path="ext/error_prone_annotations-2.11.0.jar" sourcepath="ext/src/error_prone_annotations-2.11.0.jar" />
-	<classpathentry kind="lib" path="ext/j2objc-annotations-1.3.jar" sourcepath="ext/src/j2objc-annotations-1.3.jar" />
+	<classpathentry kind="lib" path="ext/checker-qual-3.37.0.jar" sourcepath="ext/src/checker-qual-3.37.0.jar" />
+	<classpathentry kind="lib" path="ext/error_prone_annotations-2.21.1.jar" sourcepath="ext/src/error_prone_annotations-2.21.1.jar" />
+	<classpathentry kind="lib" path="ext/j2objc-annotations-2.8.jar" sourcepath="ext/src/j2objc-annotations-2.8.jar" />
 	<classpathentry kind="lib" path="ext/guice-servlet-5.1.0-gb2.jar" sourcepath="ext/src/guice-servlet-5.1.0-gb2.jar" />
 	<classpathentry kind="lib" path="ext/annotations-12.0.jar" sourcepath="ext/src/annotations-12.0.jar" />
-	<classpathentry kind="lib" path="ext/log4j-1.2.17.jar" sourcepath="ext/src/log4j-1.2.17.jar" />
-	<classpathentry kind="lib" path="ext/slf4j-api-1.7.29.jar" sourcepath="ext/src/slf4j-api-1.7.29.jar" />
-	<classpathentry kind="lib" path="ext/slf4j-log4j12-1.7.29.jar" sourcepath="ext/src/slf4j-log4j12-1.7.29.jar" />
-	<classpathentry kind="lib" path="ext/javax.mail-1.5.6.jar" sourcepath="ext/src/javax.mail-1.5.6.jar" />
+	<classpathentry kind="lib" path="ext/reload4j-1.2.25.jar" sourcepath="ext/src/reload4j-1.2.25.jar" />
+	<classpathentry kind="lib" path="ext/slf4j-api-1.7.36.jar" sourcepath="ext/src/slf4j-api-1.7.36.jar" />
+	<classpathentry kind="lib" path="ext/slf4j-reload4j-1.7.36.jar" sourcepath="ext/src/slf4j-reload4j-1.7.36.jar" />
+	<classpathentry kind="lib" path="ext/javax.mail-1.5.6.jar" />
 	<classpathentry kind="lib" path="ext/activation-1.1.jar" sourcepath="ext/src/activation-1.1.jar" />
 	<classpathentry kind="lib" path="ext/javax.servlet-api-3.1.0.jar" sourcepath="ext/src/javax.servlet-api-3.1.0.jar" />
 	<classpathentry kind="lib" path="ext/jetty-servlet-9.4.49.v20220914.jar" sourcepath="ext/src/jetty-servlet-9.4.49.v20220914.jar" />
@@ -58,21 +58,21 @@
 	<classpathentry kind="lib" path="ext/mediawiki-core-1.4.jar" sourcepath="ext/src/mediawiki-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/confluence-core-1.4.jar" sourcepath="ext/src/confluence-core-1.4.jar" />
 	<classpathentry kind="lib" path="ext/org.eclipse.jgit-4.11.9.201909030838-r.jar" sourcepath="ext/src/org.eclipse.jgit-4.11.9.201909030838-r.jar" />
-	<classpathentry kind="lib" path="ext/jsch-0.1.54.jar" sourcepath="ext/src/jsch-0.1.54.jar" />
-	<classpathentry kind="lib" path="ext/jzlib-1.1.1.jar" sourcepath="ext/src/jzlib-1.1.1.jar" />
+	<classpathentry kind="lib" path="ext/jsch-0.1.54.jar" />
+	<classpathentry kind="lib" path="ext/jzlib-1.1.1.jar" />
 	<classpathentry kind="lib" path="ext/JavaEWAH-1.1.6.jar" sourcepath="ext/src/JavaEWAH-1.1.6.jar" />
-	<classpathentry kind="lib" path="ext/httpclient-4.5.2.jar" sourcepath="ext/src/httpclient-4.5.2.jar" />
-	<classpathentry kind="lib" path="ext/httpcore-4.4.4.jar" sourcepath="ext/src/httpcore-4.4.4.jar" />
+	<classpathentry kind="lib" path="ext/httpclient-4.5.2.jar" />
+	<classpathentry kind="lib" path="ext/httpcore-4.4.4.jar" />
 	<classpathentry kind="lib" path="ext/commons-logging-1.2.jar" sourcepath="ext/src/commons-logging-1.2.jar" />
-	<classpathentry kind="lib" path="ext/commons-codec-1.9.jar" sourcepath="ext/src/commons-codec-1.9.jar" />
+	<classpathentry kind="lib" path="ext/commons-codec-1.9.jar" />
 	<classpathentry kind="lib" path="ext/org.eclipse.jgit.http.server-4.11.9.201909030838-r.jar" sourcepath="ext/src/org.eclipse.jgit.http.server-4.11.9.201909030838-r.jar" />
-	<classpathentry kind="lib" path="ext/bcprov-jdk15on-1.69.jar" sourcepath="ext/src/bcprov-jdk15on-1.69.jar" />
-	<classpathentry kind="lib" path="ext/bcmail-jdk15on-1.69.jar" sourcepath="ext/src/bcmail-jdk15on-1.69.jar" />
-	<classpathentry kind="lib" path="ext/bcutil-jdk15on-1.69.jar" sourcepath="ext/src/bcutil-jdk15on-1.69.jar" />
-	<classpathentry kind="lib" path="ext/bcpkix-jdk15on-1.69.jar" sourcepath="ext/src/bcpkix-jdk15on-1.69.jar" />
+	<classpathentry kind="lib" path="ext/bcprov-jdk18on-1.76.jar" sourcepath="ext/src/bcprov-jdk18on-1.76.jar" />
+	<classpathentry kind="lib" path="ext/bcmail-jdk18on-1.76.jar" />
+	<classpathentry kind="lib" path="ext/bcutil-jdk18on-1.76.jar" sourcepath="ext/src/bcutil-jdk18on-1.76.jar" />
+	<classpathentry kind="lib" path="ext/bcpkix-jdk18on-1.76.jar" />
 	<classpathentry kind="lib" path="ext/eddsa-0.2.0.jar" sourcepath="ext/src/eddsa-0.2.0.jar" />
 	<classpathentry kind="lib" path="ext/sshd-core-1.7.0.jar" sourcepath="ext/src/sshd-core-1.7.0.jar" />
-	<classpathentry kind="lib" path="ext/mina-core-2.0.21.jar" sourcepath="ext/src/mina-core-2.0.21.jar" />
+	<classpathentry kind="lib" path="ext/mina-core-2.0.22.jar" sourcepath="ext/src/mina-core-2.0.22.jar" />
 	<classpathentry kind="lib" path="ext/rome-0.9.jar" sourcepath="ext/src/rome-0.9.jar" />
 	<classpathentry kind="lib" path="ext/jdom-1.0.jar" sourcepath="ext/src/jdom-1.0.jar" />
 	<classpathentry kind="lib" path="ext/gson-2.10.jar" sourcepath="ext/src/gson-2.10.jar" />
@@ -80,7 +80,7 @@
 	<classpathentry kind="lib" path="ext/unboundid-ldapsdk-2.3.8.jar" sourcepath="ext/src/unboundid-ldapsdk-2.3.8.jar" />
 	<classpathentry kind="lib" path="ext/ivy-2.2.0.jar" sourcepath="ext/src/ivy-2.2.0.jar" />
 	<classpathentry kind="lib" path="ext/jcalendar-1.3.2.jar" />
-	<classpathentry kind="lib" path="ext/commons-compress-1.22.jar" sourcepath="ext/src/commons-compress-1.22.jar" />
+	<classpathentry kind="lib" path="ext/commons-compress-1.24.0.jar" sourcepath="ext/src/commons-compress-1.24.0.jar" />
 	<classpathentry kind="lib" path="ext/commons-io-2.11.0.jar" sourcepath="ext/src/commons-io-2.11.0.jar" />
 	<classpathentry kind="lib" path="ext/force-partner-api-24.0.0.jar" sourcepath="ext/src/force-partner-api-24.0.0.jar" />
 	<classpathentry kind="lib" path="ext/force-wsc-24.0.0.jar" sourcepath="ext/src/force-wsc-24.0.0.jar" />
@@ -94,10 +94,10 @@
 	<classpathentry kind="lib" path="ext/jedis-2.6.2.jar" sourcepath="ext/src/jedis-2.6.2.jar" />
 	<classpathentry kind="lib" path="ext/commons-pool2-2.0.jar" sourcepath="ext/src/commons-pool2-2.0.jar" />
 	<classpathentry kind="lib" path="ext/pf4j-0.9.0.jar" sourcepath="ext/src/pf4j-0.9.0.jar" />
-	<classpathentry kind="lib" path="ext/tika-core-1.5.jar" sourcepath="ext/src/tika-core-1.5.jar" />
-	<classpathentry kind="lib" path="ext/jsoup-1.7.3.jar" sourcepath="ext/src/jsoup-1.7.3.jar" />
+	<classpathentry kind="lib" path="ext/tika-core-1.28.3.jar" sourcepath="ext/src/tika-core-1.28.3.jar" />
+	<classpathentry kind="lib" path="ext/jsoup-1.14.2.jar" sourcepath="ext/src/jsoup-1.14.2.jar" />
 	<classpathentry kind="lib" path="ext/javax.activation-1.2.0.jar" sourcepath="ext/src/javax.activation-1.2.0.jar" />
-	<classpathentry kind="lib" path="ext/junit-4.12.jar" sourcepath="ext/src/junit-4.12.jar" />
+	<classpathentry kind="lib" path="ext/junit-4.12.jar" />
 	<classpathentry kind="lib" path="ext/hamcrest-core-1.3.jar" sourcepath="ext/src/hamcrest-core-1.3.jar" />
 	<classpathentry kind="lib" path="ext/selenium-java-2.28.0.jar" sourcepath="ext/src/selenium-java-2.28.0.jar" />
 	<classpathentry kind="lib" path="ext/selenium-support-2.28.0.jar" sourcepath="ext/src/selenium-support-2.28.0.jar" />
@@ -111,7 +111,7 @@
 	<classpathentry kind="lib" path="ext/mockito-core-2.28.2.jar" sourcepath="ext/src/mockito-core-2.28.2.jar" />
 	<classpathentry kind="lib" path="ext/byte-buddy-1.9.10.jar" sourcepath="ext/src/byte-buddy-1.9.10.jar" />
 	<classpathentry kind="lib" path="ext/byte-buddy-agent-1.9.10.jar" sourcepath="ext/src/byte-buddy-agent-1.9.10.jar" />
-	<classpathentry kind="lib" path="ext/objenesis-2.6.jar" sourcepath="ext/src/objenesis-2.6.jar" />
+	<classpathentry kind="lib" path="ext/objenesis-2.6.jar" />
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
 	<classpathentry kind="src" path="src/main/dagger">
 		<attributes>

--- a/build.moxie
+++ b/build.moxie
@@ -106,16 +106,16 @@ repositories: central, eclipse-snapshots, eclipse, gitblit
 # Convenience properties for dependencies
 properties: {
   jetty.version  : 9.4.49.v20220914
-  slf4j.version  : 1.7.29
+  slf4j.version  : 1.7.36
   wicket.version : 1.4.22
   lucene.version : 5.5.2
   jgit.version   : 4.11.9.201909030838-r
   groovy.version : 2.4.4
-  bouncycastle.version : 1.69
+  bouncycastle.version : 1.76
   selenium.version : 2.28.0
   wikitext.version : 1.4
   sshd.version: 1.7.0
-  mina.version: 2.0.21
+  mina.version: 2.0.22
   guice.version : 5.1.0
   # Gitblit maintains a fork of guice-servlet
   guice-servlet.version : 5.1.0-gb2
@@ -135,11 +135,11 @@ properties: {
 dependencies:
 - compile 'com.google.inject:guice:${guice.version}' :war :fedclient
 - compile 'com.google.inject.extensions:guice-servlet:${guice-servlet.version}' :war
-- compile 'com.google.guava:guava:31.1-jre' :war :fedclient
+- compile 'com.google.guava:guava:32.1.3-jre' :war :fedclient
 - compile 'com.intellij:annotations:12.0' :war
-- compile 'log4j:log4j:1.2.17' :war :fedclient :manager
+- compile 'ch.qos.reload4j:reload4j:1.2.25' :war :fedclient :manager
 - compile 'org.slf4j:slf4j-api:${slf4j.version}' :war :fedclient :manager
-- compile 'org.slf4j:slf4j-log4j12:${slf4j.version}' :war :fedclient :manager
+- compile 'org.slf4j:slf4j-reload4j:${slf4j.version}' :war :fedclient :manager
 - compile 'com.sun.mail:javax.mail:1.5.6' :war
 - compile 'javax.servlet:javax.servlet-api:3.1.0' :fedclient
 - compile 'org.eclipse.jetty:jetty-servlet:${jetty.version}' @jar
@@ -168,9 +168,9 @@ dependencies:
 - compile 'org.fusesource.wikitext:confluence-core:${wikitext.version}' :war
 - compile 'org.eclipse.jgit:org.eclipse.jgit:${jgit.version}' :war :fedclient :manager !junit
 - compile 'org.eclipse.jgit:org.eclipse.jgit.http.server:${jgit.version}' :war :manager !junit
-- compile 'org.bouncycastle:bcprov-jdk15on:${bouncycastle.version}' :war
-- compile 'org.bouncycastle:bcmail-jdk15on:${bouncycastle.version}' :war
-- compile 'org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}' :war
+- compile 'org.bouncycastle:bcprov-jdk18on:${bouncycastle.version}' :war
+- compile 'org.bouncycastle:bcmail-jdk18on:${bouncycastle.version}' :war
+- compile 'org.bouncycastle:bcpkix-jdk18on:${bouncycastle.version}' :war
 - compile 'net.i2p.crypto:eddsa:0.2.0' :war !org.easymock
 - compile 'org.apache.sshd:sshd-core:${sshd.version}' :war !org.easymock
 - compile 'org.apache.mina:mina-core:${mina.version}' :war !org.easymock
@@ -180,7 +180,7 @@ dependencies:
 - compile 'com.unboundid:unboundid-ldapsdk:2.3.8' :war
 - compile 'org.apache.ivy:ivy:2.2.0' :war
 - compile 'com.toedter:jcalendar:1.3.2' :authority
-- compile 'org.apache.commons:commons-compress:1.22' :war
+- compile 'org.apache.commons:commons-compress:1.24.0' :war
 - compile 'commons-io:commons-io:2.11.0' :war
 - compile 'com.force.api:force-partner-api:24.0.0' :war
 - compile 'org.freemarker:freemarker:2.3.22' :war
@@ -190,8 +190,8 @@ dependencies:
 - compile 'commons-codec:commons-codec:1.9' :war
 - compile 'redis.clients:jedis:2.6.2' :war
 - compile 'ro.fortsoft.pf4j:pf4j:0.9.0' :war
-- compile 'org.apache.tika:tika-core:1.5' :war
-- compile 'org.jsoup:jsoup:1.7.3' :war
+- compile 'org.apache.tika:tika-core:1.28.3' :war
+- compile 'org.jsoup:jsoup:1.14.2' :war
 - compile 'com.sun.activation:javax.activation:1.2.0' :war :manager :fedclient
 - test 'junit:junit:4.12'
 # Dependencies for Selenium web page testing

--- a/gitblit.iml
+++ b/gitblit.iml
@@ -48,13 +48,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="guava-31.1-jre.jar">
+      <library name="guava-32.1.3-jre.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/guava-31.1-jre.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/guava-32.1.3-jre.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/guava-31.1-jre.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/guava-32.1.3-jre.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -90,35 +90,35 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="checker-qual-3.12.0.jar">
+      <library name="checker-qual-3.37.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/checker-qual-3.12.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/checker-qual-3.37.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/checker-qual-3.12.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/checker-qual-3.37.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="error_prone_annotations-2.11.0.jar">
+      <library name="error_prone_annotations-2.21.1.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/error_prone_annotations-2.11.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/error_prone_annotations-2.21.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/error_prone_annotations-2.11.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/error_prone_annotations-2.21.1.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="j2objc-annotations-1.3.jar">
+      <library name="j2objc-annotations-2.8.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/j2objc-annotations-1.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/j2objc-annotations-2.8.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/j2objc-annotations-1.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/j2objc-annotations-2.8.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -145,35 +145,35 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="log4j-1.2.17.jar">
+      <library name="reload4j-1.2.25.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/log4j-1.2.17.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/reload4j-1.2.25.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/log4j-1.2.17.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/reload4j-1.2.25.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="slf4j-api-1.7.29.jar">
+      <library name="slf4j-api-1.7.36.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/slf4j-api-1.7.29.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/slf4j-api-1.7.36.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/slf4j-api-1.7.29.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/slf4j-api-1.7.36.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="slf4j-log4j12-1.7.29.jar">
+      <library name="slf4j-reload4j-1.7.36.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/slf4j-log4j12-1.7.29.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/slf4j-reload4j-1.7.36.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/slf4j-log4j12-1.7.29.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/slf4j-reload4j-1.7.36.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -183,9 +183,7 @@
           <root url="jar://$MODULE_DIR$/ext/javax.mail-1.5.6.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/javax.mail-1.5.6.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -588,9 +586,7 @@
           <root url="jar://$MODULE_DIR$/ext/jsch-0.1.54.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/jsch-0.1.54.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -599,9 +595,7 @@
           <root url="jar://$MODULE_DIR$/ext/jzlib-1.1.1.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/jzlib-1.1.1.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -621,9 +615,7 @@
           <root url="jar://$MODULE_DIR$/ext/httpclient-4.5.2.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/httpclient-4.5.2.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -632,9 +624,7 @@
           <root url="jar://$MODULE_DIR$/ext/httpcore-4.4.4.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/httpcore-4.4.4.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -654,9 +644,7 @@
           <root url="jar://$MODULE_DIR$/ext/commons-codec-1.9.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/commons-codec-1.9.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -671,47 +659,43 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="bcprov-jdk15on-1.69.jar">
+      <library name="bcprov-jdk18on-1.76.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/bcprov-jdk15on-1.69.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/bcprov-jdk18on-1.76.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/bcprov-jdk15on-1.69.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/bcprov-jdk18on-1.76.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="bcmail-jdk15on-1.69.jar">
+      <library name="bcmail-jdk18on-1.76.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/bcmail-jdk15on-1.69.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/bcmail-jdk18on-1.76.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="bcutil-jdk18on-1.76.jar">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/ext/bcutil-jdk18on-1.76.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/bcmail-jdk15on-1.69.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/bcutil-jdk18on-1.76.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="bcutil-jdk15on-1.69.jar">
+      <library name="bcpkix-jdk18on-1.76.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/bcutil-jdk15on-1.69.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/bcpkix-jdk18on-1.76.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/bcutil-jdk15on-1.69.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library name="bcpkix-jdk15on-1.69.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/bcpkix-jdk15on-1.69.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/bcpkix-jdk15on-1.69.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library">
@@ -737,13 +721,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="mina-core-2.0.21.jar">
+      <library name="mina-core-2.0.22.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/mina-core-2.0.21.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/mina-core-2.0.22.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/mina-core-2.0.21.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/mina-core-2.0.22.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -823,13 +807,13 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="commons-compress-1.22.jar">
+      <library name="commons-compress-1.24.0.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/commons-compress-1.22.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/commons-compress-1.24.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/commons-compress-1.22.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/commons-compress-1.24.0.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -977,24 +961,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="tika-core-1.5.jar">
+      <library name="tika-core-1.28.3.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/tika-core-1.5.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/tika-core-1.28.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/tika-core-1.5.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/tika-core-1.28.3.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="jsoup-1.7.3.jar">
+      <library name="jsoup-1.14.2.jar">
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/ext/jsoup-1.7.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/jsoup-1.14.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/jsoup-1.7.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/ext/src/jsoup-1.14.2.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -1015,9 +999,7 @@
           <root url="jar://$MODULE_DIR$/ext/junit-4.12.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/junit-4.12.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
@@ -1169,9 +1151,7 @@
           <root url="jar://$MODULE_DIR$/ext/objenesis-2.6.jar!/" />
         </CLASSES>
         <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/ext/src/objenesis-2.6.jar!/" />
-        </SOURCES>
+        <SOURCES />
       </library>
     </orderEntry>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION
Not all possible update are applied as some of them required API changes.

When running grype 0.71.0, it now returns:

    NAME              INSTALLED              FIXED-IN              TYPE          VULNERABILITY        SEVERITY
    httpclient        4.5.2                  4.5.13                java-archive  GHSA-7r82-7xv7-xcpj  Medium
    jdom              1.0                                          java-archive  GHSA-2363-cqg2-863c  High
    jsoup             1.14.2                 1.15.3                java-archive  GHSA-gp7f-rwcx-9369  Medium
    org.eclipse.jgit  4.11.9.201909030838-r  6.6.1.202309021850-r  java-archive  GHSA-3p86-9955-h393  High
    sshd-core         1.7.0                  2.9.2                 java-archive  GHSA-fhw8-8j55-vwgq  Critical
    sshd-core         1.7.0                  2.10.0                java-archive  GHSA-mjmq-gwgm-5qhm  Medium